### PR TITLE
Add logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required
+sudo: false
 dist: trusty
-language: cpp
+language: generic
 
 branches:
   only:
@@ -21,13 +21,11 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
+            - llvm-toolchain-trusty-4.0
           packages:
-            - clang-3.7
-      env: COMPILER=clang++-3.7
+            - clang-4.0
+      env: COMPILER=clang++-4.0
 
-before_install:
-  - sudo apt-get update -qq
 before_script:
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-4.0
           packages:
+            - g++-5
             - clang-4.0
       env: COMPILER=clang++-4.0
 

--- a/legacy/core/Makefile.am
+++ b/legacy/core/Makefile.am
@@ -27,6 +27,7 @@ liblegacycore_la_SOURCES = \
   config_file.h       config_file.cpp \
   config_paths.h      config_paths.cpp \
   filesystem.h        filesystem.cpp \
+  logger.h \
   posix_filesystem.h  posix_filesystem.cpp \
   random.h            random.cpp
 

--- a/legacy/core/Makefile.am
+++ b/legacy/core/Makefile.am
@@ -27,7 +27,7 @@ liblegacycore_la_SOURCES = \
   config_file.h       config_file.cpp \
   config_paths.h      config_paths.cpp \
   filesystem.h        filesystem.cpp \
-  logger.h \
+  logger.h            logger.cpp \
   posix_filesystem.h  posix_filesystem.cpp \
   random.h            random.cpp
 

--- a/legacy/core/logger.cpp
+++ b/legacy/core/logger.cpp
@@ -20,6 +20,11 @@
  */
 #include "legacy/core/logger.h"
 
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
 namespace Legacy
 {
 namespace Core
@@ -29,7 +34,7 @@ namespace Core
 std::ostream&
 operator<<(std::ostream& ostr, LogLevel level)
 {
-  auto buf = dynamic_cast<DebugStreambuf<char>*>(ostr.rdbuf());
+  auto buf = dynamic_cast<DebugStreambuf*>(ostr.rdbuf());
   if (buf)
   {
     buf->set_level(level);
@@ -41,13 +46,83 @@ operator<<(std::ostream& ostr, LogLevel level)
 std::ostream&
 operator<<(std::ostream& ostr, LogTagSetter const lts)
 {
-  auto buf = dynamic_cast<DebugStreambuf<char>*>(ostr.rdbuf());
+  auto buf = dynamic_cast<DebugStreambuf*>(ostr.rdbuf());
   if (buf)
   {
     buf->set_tag(lts.tag());
   }
   return ostr;
 }
+
+
+std::ostream&
+operator<<(std::ostream& ostr, ShowTimeSetter const sts)
+{
+  auto buf = dynamic_cast<DebugStreambuf*>(ostr.rdbuf());
+  if (buf)
+  {
+    buf->set_show_time(sts.show_time());
+  }
+  return ostr;
+}
+
+
+DebugStreambuf::
+DebugStreambuf(std::streambuf* real_buf)
+: real_buf_(real_buf)
+, bol_(true)
+, level_(LogLevel::INFO)
+, show_time_(false)
+{ }
+
+
+DebugStreambuf::int_type DebugStreambuf::
+overflow(DebugStreambuf::int_type c)
+{
+  int_type retval = traits_type::not_eof(c);
+  if (!traits_type::eq_int_type(c, traits_type::eof()))
+  {
+    if (bol_)
+    {
+      if (show_time_)
+      {
+        auto now = std::chrono::system_clock::now();
+        auto in_time_t = std::chrono::system_clock::to_time_t(now);
+
+        std::stringstream ss;
+        ss << std::put_time(std::localtime(&in_time_t), "%Y%m%dT%X");
+        auto timestamp = ss.str();
+        real_buf_->sputn(timestamp.c_str(), timestamp.length());
+      }
+
+      real_buf_->sputc('-');
+      real_buf_->sputc(static_cast<char>(level_));
+      real_buf_->sputc('-');
+      bol_ = false;
+      level_ = LogLevel::INFO;
+
+      if (!tag_.empty())
+      {
+        real_buf_->sputn(tag_.c_str(), tag_.length());
+        real_buf_->sputc(' ');
+        tag_.clear();
+      }
+    }
+
+    // Send the real character out.
+    retval =  real_buf_->sputc(c);
+
+    // If the end-of-line was seen, reset the beginning-of-line indicator and
+    // the default log level.
+    if (traits_type::eq_int_type(c, traits_type::to_int_type('\n')))
+    {
+      bol_ = true;
+    }
+  }
+
+  return retval;
+}
+
 
 } // namespace Core
 } // namespace Legacy

--- a/legacy/core/logger.cpp
+++ b/legacy/core/logger.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file legacy/core/logger.h
+ * @brief Public interface of the Legacy core logger submodule.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb <stephen.webb@bregmasoft.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "legacy/core/logger.h"
+
+namespace Legacy
+{
+namespace Core
+{
+
+
+std::ostream&
+operator<<(std::ostream& ostr, LogLevel level)
+{
+  auto buf = dynamic_cast<DebugStreambuf<char>*>(ostr.rdbuf());
+  if (buf)
+  {
+    buf->set_level(level);
+  }
+  return ostr;
+}
+
+
+std::ostream&
+operator<<(std::ostream& ostr, LogTagSetter const lts)
+{
+  auto buf = dynamic_cast<DebugStreambuf<char>*>(ostr.rdbuf());
+  if (buf)
+  {
+    buf->set_tag(lts.tag());
+  }
+  return ostr;
+}
+
+} // namespace Core
+} // namespace Legacy
+
+

--- a/legacy/core/logger.h
+++ b/legacy/core/logger.h
@@ -1,0 +1,80 @@
+/**
+ * @file legacy/core/logger.h
+ * @brief Public interface of the Legacy core logger submodule.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb <stephen.webb@bregmasoft.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LEGACY_CORE_LOGGER_H
+#define LEGACY_CORE_LOGGER_H
+
+#include <iosfwd>
+#include <fstream>
+
+
+namespace Legacy
+{
+namespace Core
+{
+
+
+/**
+ * An RAII object to redirect/restore the original stream buffer of an
+ * ostream object.
+ *
+ * This is necessary because otherwise tearing down the original ostream
+ * may result in undefined behaviour, such as a crash on shutdown.
+ */
+class StreambufRedirector
+{
+public:
+  explicit
+  StreambufRedirector(std::ostream& wrapped_ostream)
+  : wrapped_ostream_(wrapped_ostream)
+  , original_streambuf_(wrapped_ostream_.rdbuf())
+  { }
+
+  virtual
+  ~StreambufRedirector()
+  { wrapped_ostream_.rdbuf(original_streambuf_); }
+
+protected:
+  std::ostream&   wrapped_ostream_;
+  std::streambuf* original_streambuf_;
+};
+
+
+/**
+ * An RAII object to redirect an ostream to a named file.
+ */
+class StreamRedirector
+: public StreambufRedirector
+{
+public:
+  StreamRedirector(std::ostream& stream, std::string const& filename)
+  : StreambufRedirector(stream)
+  , file_(filename)
+  { wrapped_ostream_.rdbuf(file_.rdbuf()); }
+
+private:
+  std::ofstream file_;
+};
+
+
+} // namespace Core
+} // namespace Legacy
+
+#endif /* LEGACY_CORE_LOGGER_H */

--- a/legacy/core/logger.h
+++ b/legacy/core/logger.h
@@ -64,7 +64,7 @@ private:
   { }
 
   friend LogTagSetter const
-  logTag(std::string const& tag);
+  log_tag(std::string const& tag);
 
 private:
   std::string const& tag_;
@@ -74,7 +74,7 @@ private:
  * IO manipulator function to set the log tag for a line.
  */
 inline LogTagSetter const
-logTag(std::string const& tag)
+log_tag(std::string const& tag)
 { return LogTagSetter(tag); }
 
 std::ostream&
@@ -147,7 +147,7 @@ overflow(DebugStreambuf<C,T>::int_type c)
       if (!tag_.empty())
       {
         real_buf_->sputn(tag_.c_str(), tag_.length());
-        real_buf_->sputc('-');
+        real_buf_->sputc(' ');
         tag_.clear();
       }
     }

--- a/legacy/core/tests/Makefile.am
+++ b/legacy/core/tests/Makefile.am
@@ -26,6 +26,7 @@ test_core_SOURCES = \
   test_config.cpp \
   test_config_paths.cpp \
   test_filesystem.cpp \
+  test_logger.cpp \
   test_random.cpp
 
 test_core_CPPFLAGS = \

--- a/legacy/core/tests/test_logger.cpp
+++ b/legacy/core/tests/test_logger.cpp
@@ -1,0 +1,51 @@
+/**
+ * @file legacy/core/tests/test_logger.cpp
+ * @brief Tests for the Legacy core logger module.
+ */
+
+/*
+ * Copyright 2017 Stephen M. Webb <stephen.webb@bregmasoft.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "catch.hpp"
+#include "legacy/core/logger.h"
+
+#include <fstream>
+#include <iostream>
+
+using namespace Legacy::Core;
+
+
+SCENARIO("redirect stderr to a file")
+{
+  WHEN("stderr is redirected to a know-good file")
+  {
+    std::string logfile = "/tmp/garbage";
+    std::string test_line = "line1";
+    {
+      StreamRedirector log(std::cerr, "/tmp/garbage");
+      std::cerr << test_line << "\n";
+    }
+
+    THEN("you should be able to read what is written to it.")
+    {
+      std::ifstream istr(logfile);
+      std::string line1;
+      istr >> line1;
+
+      REQUIRE(line1 == test_line);
+    }
+  }
+}

--- a/legacy/core/tests/test_logger.cpp
+++ b/legacy/core/tests/test_logger.cpp
@@ -99,10 +99,10 @@ SCENARIO("convert an ostream to a debug stream")
     std::ostringstream sstr;
     DebugRedirector redirector(sstr);
 
-    sstr << logTag("spiff") << test_string;
+    sstr << log_tag("spiff") << test_string;
     THEN("an appropriate tag is set on the output.")
     {
-      REQUIRE(sstr.str() == "-I-spiff-"+test_string);
+      REQUIRE(sstr.str() == "-I-spiff "+test_string);
     }
   }
 }

--- a/legacy/core/tests/test_logger.cpp
+++ b/legacy/core/tests/test_logger.cpp
@@ -70,10 +70,39 @@ SCENARIO("convert an ostream to a debug stream")
   {
     std::string test_string = "valuable lessons";
     std::ostringstream sstr;
-    THEN("writing to it is still a pass-through operation.")
+    DebugRedirector redirector(sstr);
+    THEN("writing to it still has the original string as a line tail.")
     {
       sstr << test_string;
-      REQUIRE(sstr.str() == test_string);
+      std::string output_line = sstr.str();
+
+      REQUIRE(output_line.substr(output_line.length() - test_string.length()) == test_string);
     }
-}
+  }
+
+  WHEN("a loglevel is set")
+  {
+    std::string test_string = "strident hippos";
+    std::ostringstream sstr;
+    DebugRedirector redirector(sstr);
+
+    sstr << LogLevel::WARNING << test_string;
+    THEN("an appropriate level is indicated on the output.")
+    {
+      REQUIRE(sstr.str() == "-W-"+test_string);
+    }
+  }
+
+  WHEN("a tag is added")
+  {
+    std::string test_string = "nordic pine";
+    std::ostringstream sstr;
+    DebugRedirector redirector(sstr);
+
+    sstr << logTag("spiff") << test_string;
+    THEN("an appropriate tag is set on the output.")
+    {
+      REQUIRE(sstr.str() == "-I-spiff-"+test_string);
+    }
+  }
 }

--- a/legacy/core/tests/test_logger.cpp
+++ b/legacy/core/tests/test_logger.cpp
@@ -24,18 +24,19 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 using namespace Legacy::Core;
 
 
 SCENARIO("redirect stderr to a file")
 {
-  WHEN("stderr is redirected to a know-good file")
+  WHEN("stderr is redirected to a known-good file")
   {
     std::string logfile = "/tmp/garbage";
     std::string test_line = "line1";
     {
-      StreamRedirector log(std::cerr, "/tmp/garbage");
+      StreamRedirector log(std::cerr, logfile);
       std::cerr << test_line << "\n";
     }
 
@@ -48,4 +49,31 @@ SCENARIO("redirect stderr to a file")
       REQUIRE(line1 == test_line);
     }
   }
+
+  WHEN("stderr is redirected to a known-bad file")
+  {
+    std::string logfile = "/garbage/garbage";
+    std::string test_line = "line1";
+
+    StreamRedirector log(std::cerr, logfile);
+
+    THEN("the stream should be left in a bad state.")
+    {
+      REQUIRE(!std::cerr);
+    }
+  }
+}
+
+SCENARIO("convert an ostream to a debug stream")
+{
+  WHEN("a stringstream is converted to a debug stream")
+  {
+    std::string test_string = "valuable lessons";
+    std::ostringstream sstr;
+    THEN("writing to it is still a pass-through operation.")
+    {
+      sstr << test_string;
+      REQUIRE(sstr.str() == test_string);
+    }
+}
 }

--- a/tools/core/find_data_file.cpp
+++ b/tools/core/find_data_file.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <iostream>
 #include "legacy/core/config.h"
+#include "legacy/core/logger.h"
 #include "legacy/core/posix_filesystem.h"
 
 using namespace Legacy::Core;
@@ -30,6 +31,8 @@ using namespace std;
 int
 main(int argc, char* argv[])
 {
+  DebugRedirector logger(cout);
+
   StringList opts { argv+1, argv+argc };
   Config config;
   PosixFileSystem filesystem;
@@ -38,13 +41,13 @@ main(int argc, char* argv[])
   StringList args(config.get("cli-args", StringList()));
   if (args.size() == 0)
   {
-    cout << "usgae: " << argv[0] << " [datafile_name]\n";
+    cerr << "usgae: " << argv[0] << " [datafile_name]\n";
   }
   else
   {
     for_each(begin(args), end(args),
               [&](string const& filename) {
-                cout << "\"" << filename << "\": ";
+                cout << log_tag("find_file") << "\"" << filename << "\": ";
                 auto istr = config.open_data_file(filesystem, filename);
                 if (istr && istr->good())
                 {

--- a/tools/core/find_data_file.cpp
+++ b/tools/core/find_data_file.cpp
@@ -32,6 +32,7 @@ int
 main(int argc, char* argv[])
 {
   DebugRedirector logger(cout);
+  cout << show_time(true);
 
   StringList opts { argv+1, argv+argc };
   Config config;


### PR DESCRIPTION
Add a simple logging facility.

## Description
Adds a simple logging facility to redirect standard streams into files and provide timestamping, severity indication, and tagging of log lines.

## Motivation and Context
Output redirection is important on Microsoft Windows, and adding severity, timestamping, and tagging allows more sophisticated debugging techniques.

## How Has This Been Tested?
- A new suite of unit tests was added explicitly for logging.
- the new facility was used in some manual test tools.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
