### PR TITLE
Add cli option processing to core config

### DIFF
--- a/legacy/core/Makefile.am
+++ b/legacy/core/Makefile.am
@@ -23,6 +23,7 @@ SUBDIRS = . tests
 noinst_LTLIBRARIES = liblegacycore.la
 
 liblegacycore_la_SOURCES = \
+  argparse.h          argparse.cpp \
   config.h            config.cpp \
   config_file.h       config_file.cpp \
   config_paths.h      config_paths.cpp \

--- a/legacy/core/argparse.cpp
+++ b/legacy/core/argparse.cpp
@@ -1,0 +1,272 @@
+
+/**
+ * @file legacy/core/argparse.cpp
+ * @brief Implementation of the Legacy core command-line arguemnt parsing submodule.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb <stephen.webb@bregmasoft.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "legacy/core/argparse.h"
+
+#include <cassert>
+#include "legacy/core/config.h"
+#include <iostream>
+#include <stdexcept>
+
+
+namespace Legacy
+{
+namespace Core
+{
+namespace CLI
+{
+
+ActionResult
+append(std::string name, std::vector<std::string> args, Config& config)
+{
+  if (args.size() < 1)
+    return ActionResult::MISSING_ARG;
+
+  StringList string_list = config.get<StringList>(name, StringList());
+  for (auto const& s: args)
+  {
+    string_list.push_back(s);
+  }
+  config.set<StringList>(name, string_list);
+
+  return ActionResult::SUCCESS;
+}
+
+
+ActionResult
+count(std::string name, std::vector<std::string> args, Config& config)
+{
+  if (args.size() > 0)
+    return ActionResult::TOO_MANY_ARGS;
+
+  int count = config.get<int>(name, 0);
+  config.set<int>(name, count + 1);
+
+  return ActionResult::SUCCESS;
+}
+
+
+ActionResult
+store_int(std::string name, std::vector<std::string> args, Config& config)
+{
+  if (args.size() < 1)
+    return ActionResult::MISSING_ARG;
+  if (args.size() > 1)
+    return ActionResult::TOO_MANY_ARGS;
+
+  try
+  {
+    int val = std::stoi(args[0]);
+    config.set<int>(name, val);
+  }
+  catch (std::exception const&)
+  {
+    return ActionResult::INVALID_ARG;
+  }
+
+  return ActionResult::SUCCESS;
+}
+
+
+ActionResult
+store_string(std::string name, std::vector<std::string> args, Config& config)
+{
+  if (args.size() < 1)
+    return ActionResult::MISSING_ARG;
+
+  std::string string_val;
+  for (auto const& s: args) string_val += s;
+  config.set<std::string>(name, string_val);
+
+  return ActionResult::SUCCESS;
+}
+
+
+ActionResult
+store_true(std::string name, std::vector<std::string> args, Config& config)
+{
+  if (args.size() > 0)
+    return ActionResult::TOO_MANY_ARGS;
+
+  config.set<int>(name, 1);
+  return ActionResult::SUCCESS;
+}
+
+
+ActionResult
+store_false(std::string name, std::vector<std::string> args, Config& config)
+{
+  if (args.size() > 0)
+    return ActionResult::TOO_MANY_ARGS;
+
+  config.set<int>(name, 0);
+  return ActionResult::SUCCESS;
+}
+
+
+ActionResult
+version(std::string, std::vector<std::string>, Config&)
+{
+  // @TODO: maybe later
+  return ActionResult::INVALID_ARG;
+}
+
+
+namespace
+{
+
+/**
+ * Indicates if the passed argument is an option (begins with a '-') or not.
+ */
+bool
+arg_is_option(std::string const& arg)
+{
+  if (arg.length() < 2)
+    return false;
+
+  return arg[0] == '-';
+}
+
+/**
+ * Indicates if the passed option is a long-form or a short-form option.
+ */
+bool
+option_is_short_option(std::string const& option)
+{
+  assert(option.length() >= 2);
+  return option[1] != '-';
+}
+
+/**
+ * Looks for the Option in the option set matching the option found in the
+ * command line.
+ *
+ * @returns the index of the Option found, or the index of one-past-the-end of
+ * the option_set if not found.
+ */
+OptionSet::size_type
+match_option(std::string const& option, OptionSet const& option_set)
+{
+  if (option_is_short_option(option))
+  {
+    for (OptionSet::size_type optind = 0; optind < option_set.size(); ++optind)
+    {
+      if (option_set[optind].short_option == option[1])
+      {
+        return optind;
+      }
+    }
+  }
+  else
+  {
+    for (OptionSet::size_type optind = 0; optind < option_set.size(); ++optind)
+    {
+      if (option_set[optind].name == option)
+      {
+        return optind;
+      }
+    }
+  }
+  return option_set.size();
+}
+
+std::string
+get_config_key_from_option(Option const& option)
+{
+  if (!option.config_key.empty())
+  {
+    return option.config_key;
+  }
+  if (option.name.length() > 2 && option.name[0] == '-' && option.name[1] == '-')
+  {
+    return option.name.substr(2);
+  }
+  return option.name;
+}
+
+} // anonymous namespace
+
+
+ArgParseResult
+arg_parse(OptionSet const& option_set, std::vector<std::string> args, Config& config)
+{
+  ArgParseResult parse_result = ArgParseResult::SUCCESS;
+
+  std::vector<std::string>::size_type arg_index = 0;
+  if (args.size() < 1)
+    return ArgParseResult::INVALID_OPTION;
+
+  std::string prog_name = args[arg_index++];
+
+  while (arg_index < args.size())
+  {
+    std::string const& arg = args[arg_index];
+    if (arg == "--version" || arg == "-v")
+    {
+      version("version", std::vector<std::string>(), config);
+      return ArgParseResult::SUCCESS_AND_EXIT;
+    }
+    else if (arg == "--help" || arg == "-h")
+    {
+      return ArgParseResult::SUCCESS_AND_EXIT;
+    }
+
+    if (arg_is_option(arg))
+    {
+      auto optind = match_option(arg, option_set);
+      if (optind < option_set.size())
+      {
+        auto const& option = option_set[optind];
+        std::vector<std::string> optargs;
+        int i = 0;
+        while (i < option.num_args && arg_index + i < (args.size()-1))
+        {
+          ++i;
+          optargs.push_back(args[arg_index+i]);
+        }
+        arg_index += i;
+        auto result = option.action(get_config_key_from_option(option), optargs, config);
+        if (result != ActionResult::SUCCESS)
+        {
+          parse_result = ArgParseResult::INVALID_OPTION;
+        }
+      }
+      else
+      {
+        parse_result = ArgParseResult::INVALID_OPTION;
+      }
+    }
+    else
+    {
+std::clog << "==smw> arg is not an option\n";
+      // TBD
+    }
+    ++arg_index;
+  }
+
+  return parse_result;
+}
+
+
+} // namespace CLI
+} // namespace Core
+} // namespace Legacy
+

--- a/legacy/core/argparse.h
+++ b/legacy/core/argparse.h
@@ -1,0 +1,188 @@
+/**
+ * @file legacy/core/argparse.h
+ * @brief Public interface of the Legacy core command-line arguemnt parsing submodule.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb <stephen.webb@bregmasoft.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LEGACY_CORE_ARGPARSE_H
+#define LEGACY_CORE_ARGPARSE_H
+
+#include <functional>
+#include <string>
+#include <vector>
+
+
+namespace Legacy
+{
+namespace Core
+{
+
+class Config;
+
+namespace CLI
+{
+
+/**
+ * Possible results when parsing an option and its arguments.
+ */
+enum class ActionResult
+{
+  SUCCESS,
+  INVALID_ARG,
+  MISSING_ARG,
+  TOO_MANY_ARGS
+};
+
+
+/**
+ * The callback type for processing options and their arguments.
+ */
+using OptionAction = std::function<ActionResult(std::string              name,
+                                                std::vector<std::string> args,
+                                                Config&                  config)>;
+
+/**
+ * Appends the argument list to a StringList.
+ */
+ActionResult
+append(std::string name, std::vector<std::string> args, Config& config);
+
+/**
+ * Increments the int value.
+ */
+ActionResult
+count(std::string name, std::vector<std::string> args, Config& config);
+
+/**
+ * Stores the int value.
+ */
+ActionResult
+store_int(std::string name, std::vector<std::string> args, Config& config);
+
+/**
+ * Stores the string value.
+ */
+ActionResult
+store_string(std::string name, std::vector<std::string> args, Config& config);
+
+/**
+ * Sets the boolean value.
+ */
+ActionResult
+store_true(std::string name, std::vector<std::string> args, Config& config);
+
+/**
+ * Clears the boolean value.
+ */
+ActionResult
+store_false(std::string name, std::vector<std::string> args, Config& config);
+
+/**
+ * Prints the version string and exits.
+ */
+ActionResult
+version(std::string name, std::vector<std::string> args, Config& config);
+
+
+/**
+ * A description of an individual command-line option.
+ */
+struct Option
+{
+  /**
+   * The name of the option or positional argument.
+   *
+   * Names beginning with two dashes are long-form command-line options,
+   * anything else is named positional parameter.
+   */
+  std::string  name;
+
+  /**
+   * The (optional) single-letter command-line switch.
+   * A zero indicates no short option equivalent, and the value is ignored if
+   * the name is not a long-form command line option.
+   */
+  char         short_option;
+
+  /**
+   * The number of arguments expected by the command-line option.
+   *
+   * Most options are going to take 0 or 1 arguments, but there is no upper
+   * limit, keeping in mind more than 1 integer value does not make sense here.
+   *
+   * If a specific integer is indicated that number of arguments is mandatory.
+   *
+   * The special values of '*' (for zero or more arguments, up until the next
+   * option) and '+' (for at least one but more up until the next option) are
+   * available, under the assumption that 42 or 43 required arguments are
+   * ridiculous.
+   */
+  int          num_args;
+
+  /**
+   * What action to take with the option and/or arguments.
+   *
+   * A set of functions (cf.) are provided with basic operations, or a custom
+   * function may be passed.
+   */
+  OptionAction action;
+
+  /**
+   * The Config key value for the option value(s).  If this is the empty string,
+   * then a default key is created by trimming off any leading '--' fro the name
+   * and using that as the key.
+   */
+  std::string  config_key;
+
+  /**
+   * A descriptive string to appear in the usage/help message.
+   */
+  std::string  description;
+};
+
+
+/**
+ * The set of command-line options to be parsed.
+ */
+using OptionSet = std::vector<Option>;
+
+/**
+ * Possible results from parsing the command-line arguments.
+ */
+enum struct ArgParseResult
+{
+  SUCCESS,
+  SUCCESS_AND_EXIT,
+  INVALID_OPTION
+};
+
+
+/**
+ * Parses the given command-line arguments into a COnfig object using the option_list as rules.
+ *
+ * @arg[in]  option_set the set of options expected
+ * @arg[in]  args       the set of command-line arguments supplied
+ * @arg[out] config     the Config object into which the parsed arguments should be put
+ */
+ArgParseResult
+arg_parse(OptionSet const& option_set, std::vector<std::string> args, Config& config);
+
+} // namespace CLI
+} // namespace Core
+} // namespace Legacy
+
+#endif /* LEGACY_CORE_ARGPARSE_H */

--- a/legacy/core/config.cpp
+++ b/legacy/core/config.cpp
@@ -227,30 +227,12 @@ set(std::string const& tag, StringList value)
 }
 
 
-void Config::
-init(StringList const& args, FileSystem const& fs)
+CLI::ArgParseResult Config::
+init(CLI::OptionSet const& option_set, StringList const& args, FileSystem const& fs)
 {
-  std::string config_file_name;
-  StringList  non_options;
-
-  for (auto it = args.begin(); it != args.end(); ++it)
-  {
-    if (*it == "--config" || *it == "-f")
-    {
-      auto opt = *it++;
-      if (it == args.end())
-        throw std::runtime_error("missing argument for " + opt);
-      config_file_name = *it;
-    }
-    else if ((*it)[0] == '-')
-    {
-      std::cerr << "unknown option '"<< *it << "'\n";
-    }
-    else
-    {
-      non_options.push_back(*it);
-    }
-  }
+  auto arg_parse_result = CLI::arg_parse(option_set, args, *this);
+  if (arg_parse_result != CLI::ArgParseResult::SUCCESS)
+    return arg_parse_result;
 
   config_paths_ = generate_config_paths();
   std::for_each(config_paths_.crbegin(), config_paths_.crend(),
@@ -265,7 +247,7 @@ init(StringList const& args, FileSystem const& fs)
   );
 
   data_paths_ = generate_data_paths();
-  set<StringList>("cli-args", non_options);
+  return arg_parse_result;
 }
 
 

--- a/legacy/core/config.h
+++ b/legacy/core/config.h
@@ -21,6 +21,7 @@
 #ifndef LEGACY_CORE_CONFIG_H
 #define LEGACY_CORE_CONFIG_H
 
+#include "legacy/core/argparse.h"
 #include "legacy/core/filesystem.h"
 #include <map>
 #include <string>
@@ -59,8 +60,8 @@ public:
    * on the command line and set in config files, for which the loading order
    * can be affected by the command-line arguments.
    */
-  void
-  init(StringList const& argv, FileSystem const& fs);
+  CLI::ArgParseResult
+  init(CLI::OptionSet const& option_set, StringList const& argv, FileSystem const& fs);
 
   template<typename T> T
   get(std::string const& tag);

--- a/legacy/core/tests/Makefile.am
+++ b/legacy/core/tests/Makefile.am
@@ -22,6 +22,7 @@ check_PROGRAMS = test_core
 
 test_core_SOURCES = \
   mock_filesystem.h      mock_filesystem.cpp \
+  test_argparse.cpp \
   test_core.cpp \
   test_config.cpp \
   test_config_paths.cpp \

--- a/legacy/core/tests/test_argparse.cpp
+++ b/legacy/core/tests/test_argparse.cpp
@@ -284,3 +284,46 @@ SCENARIO("two positional arguments are expected")
     }
   }
 }
+
+SCENARIO("positional arguments with wildcard count is expected")
+{
+  CLI::OptionSet option_set = {
+    { "positional-arg",  0, '+', CLI::append, "", "a positional argument" },
+  };
+  Config config;
+
+  WHEN("two values are passed")
+  {
+    StringList args = { "prog", "value1", "value2" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      StringList expected_results{ "value1", "value2" };
+      REQUIRE(config.get<StringList>("positional-arg") == expected_results);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("no value is passed")
+  {
+    StringList args = { "prog" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+
+  WHEN("only one value is passed")
+  {
+    StringList args = { "prog", "rock" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      StringList expected_results{ "rock" };
+      REQUIRE(config.get<StringList>("positional-arg") == expected_results);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+}
+

--- a/legacy/core/tests/test_argparse.cpp
+++ b/legacy/core/tests/test_argparse.cpp
@@ -292,18 +292,6 @@ SCENARIO("positional arguments with wildcard count is expected")
   };
   Config config;
 
-  WHEN("two values are passed")
-  {
-    StringList args = { "prog", "value1", "value2" };
-    THEN("it is properly stored in the Config object and success is returned.")
-    {
-      auto result = CLI::arg_parse(option_set, args, config);
-      StringList expected_results{ "value1", "value2" };
-      REQUIRE(config.get<StringList>("positional-arg") == expected_results);
-      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
-    }
-  }
-
   WHEN("no value is passed")
   {
     StringList args = { "prog" };
@@ -321,6 +309,65 @@ SCENARIO("positional arguments with wildcard count is expected")
     {
       auto result = CLI::arg_parse(option_set, args, config);
       StringList expected_results{ "rock" };
+      REQUIRE(config.get<StringList>("positional-arg") == expected_results);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("two values are passed")
+  {
+    StringList args = { "prog", "value1", "value2" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      StringList expected_results{ "value1", "value2" };
+      REQUIRE(config.get<StringList>("positional-arg") == expected_results);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+}
+
+SCENARIO("mixed short, long, and positional arguments")
+{
+  CLI::OptionSet option_set = {
+    { "--string",       's', 1,  CLI::store_string, "", "a string option" },
+    { "positional-arg",  0, '+', CLI::append, "", "a positional argument" },
+  };
+  Config config;
+
+  WHEN("option arg is passed")
+  {
+    StringList args = { "prog", "--string", "value", "arg" };
+    THEN("they are properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<std::string>("string") == "value");
+      REQUIRE(config.get<StringList>("positional-arg") == StringList{"arg"});
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("arg option is passed")
+  {
+    StringList args = { "prog", "arg", "--string", "value" };
+    THEN("they are properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<std::string>("string") == "value");
+      REQUIRE(config.get<StringList>("positional-arg") == StringList{"arg"});
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("arg option arg is passed")
+  {
+    StringList args = { "prog", "arg1", "--string", "value", "arg2" };
+    THEN("they are properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<std::string>("string") == "value");
+      StringList expected_results{ "arg1", "arg2" };
       REQUIRE(config.get<StringList>("positional-arg") == expected_results);
       REQUIRE(result == CLI::ArgParseResult::SUCCESS);
     }

--- a/legacy/core/tests/test_argparse.cpp
+++ b/legacy/core/tests/test_argparse.cpp
@@ -215,3 +215,72 @@ SCENARIO("some basic simple options are expected")
     }
   }
 }
+
+SCENARIO("one positional arguments is expected")
+{
+  CLI::OptionSet option_set = {
+    { "positional-arg",  0,  1, CLI::store_string, "", "a positional argument" },
+  };
+  Config config;
+
+  WHEN("a value is passed")
+  {
+    StringList args = { "prog", "value" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<std::string>("positional-arg") == "value");
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("no value is passed")
+  {
+    StringList args = { "prog" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+}
+
+SCENARIO("two positional arguments are expected")
+{
+  CLI::OptionSet option_set = {
+    { "positional-arg",  0,  2, CLI::append, "", "a positional argument" },
+  };
+  Config config;
+
+  WHEN("two values are passed")
+  {
+    StringList args = { "prog", "value1", "value2" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      StringList expected_results{ "value1", "value2" };
+      REQUIRE(config.get<StringList>("positional-arg") == expected_results);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("no value is passed")
+  {
+    StringList args = { "prog" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+
+  WHEN("only one value is passed")
+  {
+    StringList args = { "prog", "rock" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+}

--- a/legacy/core/tests/test_argparse.cpp
+++ b/legacy/core/tests/test_argparse.cpp
@@ -1,0 +1,217 @@
+/**
+ * @file legacy/core/tests/test_argparse.cpp
+ * @brief Tests for the Legacy core argparse module.
+ */
+
+/*
+ * Copyright 2017 Stephen M. Webb <stephen.webb@bregmasoft.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "catch.hpp"
+#include "legacy/core/argparse.h"
+
+#include "legacy/core/config.h"
+
+
+using namespace Legacy::Core;
+
+
+SCENARIO("no options expected")
+{
+  CLI::OptionSet option_set = { };
+  Config config;
+
+  WHEN("the version is requested")
+  {
+    StringList args = { "prog", "--version" };
+    THEN("a version string is printed on stderr and success-with-exit is returned")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS_AND_EXIT);
+    }
+  }
+
+  WHEN("help is requested")
+  {
+    StringList args = { "prog", "--help" };
+    THEN("a help message is printed on stderr and success-with-exit is returned")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS_AND_EXIT);
+    }
+  }
+
+  WHEN("an unexpect option is submitted")
+  {
+    StringList args = { "prog", "--garbage", "trash" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+}
+
+SCENARIO("some basic simple options are expected")
+{
+  CLI::OptionSet option_set = {
+    { "--append",  'a',  1, CLI::append,       "", "test StringList appending" },
+    { "--string",  's',  1,  CLI::store_string, "", "test string storage" },
+    { "--int",     'i',  1,  CLI::store_int,    "", "test int storage" },
+    { "--true",    't',  0,  CLI::store_true,   "", "test true storage" },
+    { "--unfalse", 'u',  1,  CLI::store_true,   "", "test true storage with useless argument" },
+    { "--false",   'f',  0,  CLI::store_false,  "", "test false storage" },
+  };
+  Config config;
+
+  WHEN("a string long option is passed")
+  {
+    StringList args = { "prog", "--string", "buffalo" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<std::string>("string") == "buffalo");
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("a string short option is passed")
+  {
+    StringList args = { "prog", "-s", "bison" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<std::string>("string") == "bison");
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("a string long option is passed without an argument")
+  {
+    StringList args = { "prog", "--string" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+
+  WHEN("an int long option is passed")
+  {
+    StringList args = { "prog", "--int", "7" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<int>("int") == 7);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("an int short option is passed")
+  {
+    StringList args = { "prog", "-i", "8" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<int>("int") == 8);
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("an int long option is passed with a missing argument")
+  {
+    StringList args = { "prog", "--int" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+
+  WHEN("an int long option is passed with an invalid argument")
+  {
+    StringList args = { "prog", "--int", "kk" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+
+  WHEN("a bool(true) long option is passed")
+  {
+    StringList args = { "prog", "--true" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<int>("true"));
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("a bool(true) short option is passed")
+  {
+    StringList args = { "prog", "-t" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<int>("true"));
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("a bool(true) long option is passed but an argument is expected")
+  {
+    StringList args = { "prog", "--unfalse", "z" };
+    THEN("failure is indicated.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(result == CLI::ArgParseResult::INVALID_OPTION);
+    }
+  }
+
+  WHEN("a bool(false) long option is passed")
+  {
+    StringList args = { "prog", "--false" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(!config.get<int>("false"));
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("a bool(false) short option is passed")
+  {
+    StringList args = { "prog", "-f" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(!config.get<int>("false"));
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+
+  WHEN("an append option is passed")
+  {
+    StringList args = { "prog", "--append", "one" };
+    THEN("it is properly stored in the Config object and success is returned.")
+    {
+      auto result = CLI::arg_parse(option_set, args, config);
+      REQUIRE(config.get<StringList>("append") == StringList{ "one" });
+      REQUIRE(result == CLI::ArgParseResult::SUCCESS);
+    }
+  }
+}

--- a/legacy/core/tests/test_config.cpp
+++ b/legacy/core/tests/test_config.cpp
@@ -240,10 +240,10 @@ SCENARIO("Finding a data file.")
 {
   GIVEN("an empty set of command-line arguments")
   {
-    StringList argv;
+    StringList argv{ "test_config" };
     Legacy::Core::Config config;
     Legacy::Core::Tests::MockFileSystem mock_filesystem;
-    config.init(argv, mock_filesystem);
+    config.init(Legacy::Core::CLI::OptionSet(), argv, mock_filesystem);
 
     WHEN("a request is made to open a non-existent file")
     {

--- a/tools/core/find_data_file.cpp
+++ b/tools/core/find_data_file.cpp
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include "legacy/core/config.h"
 #include "legacy/core/logger.h"


### PR DESCRIPTION
Adds basic CLI argument handling to the core config module.

## Description

Provides configurable processing for long and short command-line options and positional arguments, and integrated that in the config object setup.

## Motivation and Context

Allows the game, tools, and test drivers to share a common configuraion object that can be modified at program start by using the command line.

## How Has This Been Tested?

- New unit test for the core/argparse module.
- modified unit tests for the core/config module to accommodate changed API.
- modified some test driver tools to use the new argparse+config to replace the standard getopt() processing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
